### PR TITLE
CustomComponent prop types

### DIFF
--- a/gw2-ui/src/components/CustomComponent/CustomComponent.tsx
+++ b/gw2-ui/src/components/CustomComponent/CustomComponent.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
-import { CSSProperties, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { ProfessionTypes } from '../../data/professions';
 import GW2ApiSkill from '../../gw2api/types/skills/skill';
 import AbilityDetails from '../AbilityDetails/AbilityDetails';
-import IconWithText from '../IconWithText/IconWithText';
+import IconWithText, { IconWithTextProps } from '../IconWithText/IconWithText';
 import professioncss from '../Profession/professions.module.css';
 import Tooltip, { TooltipProps } from '../Tooltip/Tooltip';
 import WikiLink, { WikiLinkProps } from '../WikiLink/WikiLink';
@@ -11,18 +11,15 @@ import WikiLink, { WikiLinkProps } from '../WikiLink/WikiLink';
 /**
  * Allows supplying custom data in the data props
  */
-export interface CustomComponentProps {
+export interface CustomComponentProps
+  extends Omit<IconWithTextProps, 'icon' | 'text' | 'loading'> {
   type: 'Skill' | 'Trait';
   data: unknown;
   text?: string;
-  disableIcon?: boolean;
-  disableText?: boolean;
   disableLink?: boolean;
   disableTooltip?: boolean;
   tooltipProps?: TooltipProps;
   wikiLinkProps?: WikiLinkProps;
-  style?: CSSProperties;
-  className?: string;
 }
 
 const CustomComponent = (props: CustomComponentProps): ReactElement => {


### PR DESCRIPTION
This fixes the prop types for the new `CustomComponent` to include the missing props from `IconWithTextProps`.

It could also be adjusted to have better typing than `unknown` for the passed data maybe?