### PR TITLE
Fix: Fury label

### DIFF
--- a/gw2-ui/src/gw2api/overrides/data/skills.ts
+++ b/gw2-ui/src/gw2api/overrides/data/skills.ts
@@ -586,7 +586,7 @@ export const missing_skills: Record<
         icon: 'https://render.guildwars2.com/file/96D90DF84CAFE008233DD1C2606A12C1A0E68048/102842.png',
         duration: 5,
         status: 'Fury',
-        description: 'Critical Chance increased by 20%; stacks duration.',
+        description: 'Critical Chance increased by 25%; stacks duration.',
         apply_count: 1,
       },
       {

--- a/gw2-ui/src/i18n/boons.ts
+++ b/gw2-ui/src/i18n/boons.ts
@@ -26,8 +26,8 @@ export const TRANSLATIONS_BOON_DESCRIPTIONS: Record<BoonsTypes, Translation> = {
     de: 'Fertigkeiten laden sich schneller wieder auf.',
   },
   Fury: {
-    en: 'Critical Chance increased by 20%; stacks duration.',
-    de: 'Erhöht die Chance auf kritischen Treffer um 20%; Dauer summiert sich.',
+    en: 'Critical Chance increased by 25%; stacks duration.',
+    de: 'Erhöht die Chance auf kritischen Treffer um 25%; Dauer summiert sich.',
   },
   Might: {
     en: 'Increased outgoing damage; stacks intensity.',


### PR DESCRIPTION
Changes fury critical chance from 20% to 25% in the override labels.

I don't know how to deploy this thing.