### PR TITLE
Implement API fallback

### DIFF
--- a/gw2-ui/src/gw2api/cache.ts
+++ b/gw2-ui/src/gw2api/cache.ts
@@ -1,6 +1,25 @@
 import { APILanguage } from '../i18n';
 
-const GW2_API_URL = 'https://api.guildwars2.com';
+interface ApiRoute {
+  name: string;
+  is_available: boolean;
+  create_url: (path: string, ids: number[], language: APILanguage) => string;
+}
+
+const api_routes: ApiRoute[] = [
+  {
+    name: 'Official GW2 API',
+    is_available: true,
+    create_url: (path, ids, language) =>
+      `https://api.guildwars2.com${path}?ids=${ids.join(',')}&lang=${language}`,
+  },
+  {
+    name: 'Princeps API Mirror',
+    is_available: true,
+    create_url: (path, ids, language) =>
+      `https://api.princeps.biz${path}?ids=${ids.join(',')}&lang=${language}`
+  },
+];
 
 // An error occurred when connecting to the API
 export const API_ERROR_NETWORK = 500;
@@ -220,14 +239,25 @@ export default class APICache<T extends { id: Id }> {
     let error: APIError = API_ERROR_NOT_FOUND;
     try {
       ids.sort((a, b) => a - b);
-      const url =
-        GW2_API_URL +
-        this.path +
-        '?ids=' +
-        ids.join(',') +
-        '&lang=' +
-        this.language;
+
+      const api_route = api_routes.find(({ is_available }) => is_available) ?? api_routes[0];
+
+      const url = api_route.create_url(this.path, ids, this.language);
       const res = await fetch(url, FETCH_OPTIONS);
+
+      if (res.status === 503) {
+        api_route.is_available = false;
+        if (api_routes.find(({ is_available }) => is_available)) {
+          // If an API route is unavailable, back out and retry the same ids on an alternative route
+          console.warn(`The ${api_route.name} is unavailable; switching API routes`);
+          for (const id of ids) {
+            this.fetched_ids.delete(id);
+          }
+          this.requests_inflight--;
+          this.tryFetch();
+          return;
+        }
+      }
       if (res.status === 404) {
         // 404 usually means that none of the passed ids are known, which is equivalent to an empty response
         response = [];

--- a/gw2-ui/src/gw2api/cache.ts
+++ b/gw2-ui/src/gw2api/cache.ts
@@ -1,6 +1,35 @@
 import { APILanguage } from '../i18n';
 
-const GW2_API_URL = 'https://api.guildwars2.com';
+interface ApiRoute {
+  name: string
+  is_available: boolean,
+  api_max_ids_per_request: number,
+  create_url: (path: string, ids: number[], language: APILanguage) => string
+  transform: (apiResponse: unknown) => unknown
+}
+
+const api_routes: ApiRoute[] = [
+  {
+    name: 'Official GW2 API',
+    is_available: true,
+    api_max_ids_per_request: 200,
+    create_url: (path, ids, language) =>
+      `https://api.guildwars2.com${path}?ids=${ids.join(',')}&lang=${language}`,
+    transform: (apiResponse) => apiResponse
+  },
+  {
+    name: 'GW2Treasures API',
+    is_available: true,
+    api_max_ids_per_request: 1,
+    create_url: (path, ids, language) => {
+      const modifiedPath = /(?<=\/v2\/).*(?=s)/.exec(path)?.[0];
+      if (!modifiedPath) throw new Error(`GW2Treasures alternate API could not process path ${path}`);
+
+      return `https://${language}.gw2treasures.com/${modifiedPath}/${ids[0]}/json`;
+    },
+    transform: (apiResponse) => [apiResponse]
+  },
+];
 
 // An error occurred when connecting to the API
 export const API_ERROR_NETWORK = 500;
@@ -196,12 +225,15 @@ export default class APICache<T extends { id: Id }> {
     if (this.requested_ids.size <= this.fetched_ids.size) {
       return;
     }
+
+    const api_route = api_routes.find(({ is_available }) => is_available) ?? api_routes[0];
+
     const ids: Id[] = [];
     for (const id of this.requested_ids.values()) {
       if (!this.fetched_ids.has(id)) {
         ids.push(id);
       }
-      if (ids.length >= this.max_ids_per_request) {
+      if (ids.length >= Math.min(this.max_ids_per_request, api_route.api_max_ids_per_request)) {
         break;
       }
     }
@@ -220,24 +252,34 @@ export default class APICache<T extends { id: Id }> {
     let error: APIError = API_ERROR_NOT_FOUND;
     try {
       ids.sort((a, b) => a - b);
-      const url =
-        GW2_API_URL +
-        this.path +
-        '?ids=' +
-        ids.join(',') +
-        '&lang=' +
-        this.language;
+
+      const url = api_route.create_url(this.path, ids, this.language);
       const res = await fetch(url, FETCH_OPTIONS);
+
+      if (res.status === 503) {
+        api_route.is_available = false;
+        if (api_routes.find(({ is_available }) => is_available)) {
+          // If an API route is unavailable, back out and retry the same ids on an alternative route
+          console.warn(`The ${api_route.name} is unavailable; switching API routes`);
+          for (const id of ids) {
+            this.fetched_ids.delete(id);
+          }
+          this.requests_inflight--;
+          this.tryFetch();
+          return;
+        }
+      }
       if (res.status === 404) {
         // 404 usually means that none of the passed ids are known, which is equivalent to an empty response
         response = [];
       } else {
         if (!res.ok) throw new Error(`HTTP Error: ${res.status}`);
         const json = await res.json();
-        if (!(json instanceof Array)) {
+        const transformed_json = api_route.transform(json);
+        if (!(transformed_json instanceof Array)) {
           throw new Error('Response is not a list');
         }
-        response = json;
+        response = transformed_json;
       }
     } catch (e) {
       error = API_ERROR_NETWORK;


### PR DESCRIPTION
Honestly, I don't really expect to deploy this, but maybe bits of it could be useful for something later.

This was going to be a quick modification to—as quickly as possible, because the time window when this would be useful is about two days—implement behavior that falls back to an API mirror when the official API 503s.

However, a) the object oriented structure of the `cache` objects isn't super suited for this, so the code structure I made is kind of hacky, and b) it turns out that no one I know has an actual API mirror.

To see if this would work at all, I implemented a bunch of extra transform code to allow it to hit the gw2treasures API one-at-a-time for skills and traits, which works (items don't). If one were to actually use something like this it should be with a 1:1 API mirror so none of that should be necessary.