### PR TITLE
fix: react key warnings

### DIFF
--- a/gw2-ui/src/components/Tooltip/Tooltip.tsx
+++ b/gw2-ui/src/components/Tooltip/Tooltip.tsx
@@ -74,9 +74,13 @@ const Tooltip = ({
 
   // We need to finagle a ref into the child component.
   const children_with_ref = useMemo(() => {
-    return cloneElement(children, {
-      ref: children_ref,
-    });
+    return (
+      <>
+        {cloneElement(children, {
+          ref: children_ref,
+        })}
+      </>
+    );
   }, [children]);
 
   // Render the tooltip content if visible

--- a/react-discretize-components/src/character/Character/Character.tsx
+++ b/react-discretize-components/src/character/Character/Character.tsx
@@ -92,7 +92,7 @@ const Character = ({
         </div>
 
         <div className={classes.middle}>
-          {imageElement}
+          <>{imageElement}</>
 
           {(skills || legends) && (
             <Section className={classes.skillsLegends}>


### PR DESCRIPTION
Fixes some React dev mode warnings about missing keys. Apparently using `array.map()` to output JSX isn't the only case where React wants hints about whether to replace or move items, I guess. It seems like "element that might or might not be rendered followed by another element" counts as a list. Putting a fragment around the conditionally rendered element satisfies React (I guess it uses the fragment to keep track of the place where the element would have been, I dunno.)