### PR TITLE
feat: improve narrow-view character component image layout

### DIFF
--- a/react-discretize-components/src/character/Character/Character.module.css
+++ b/react-discretize-components/src/character/Character/Character.module.css
@@ -19,18 +19,27 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  isolation: isolate;
 }
 .side {
   display: flex;
   flex: 0 0 250px;
   flex-direction: column;
   justify-content: space-between;
+  z-index: 1;
 }
 .middle {
   display: flex;
-  flex: 0.7 0.2 300px;
+  flex: 0.7 0.2;
   flex-direction: column;
   justify-content: space-between;
+}
+.middle > img {
+  width: max(100%, 450px);
+  left: 50%;
+  top: 33%;
+  position: relative;
+  transform: translate(-50%, -50%);
 }
 .skillsLegends {
   max-width: 390px;


### PR DESCRIPTION
This improves the positioning and size of the character component's profession image when the component is rendered with a narrow width, allowing it to stay large and vertically positioned and letting it be partially hidden by the tables.

I picked 450px as a minimum size and 33% vertical positioning entirely arbitrarily; someone with a better design eye should tweak.

Only tested with gear optimizer. Should be tested with main site/new site.

(Ignore missing icons in _after_ screenshots, that's because I tested with `pnpm link`).

| before | after |
| - | - |
| <img src="https://github.com/discretize/discretize-ui/assets/8336245/5e08fa10-0584-4da4-829c-64600c7731a2"> | <img src="https://github.com/discretize/discretize-ui/assets/8336245/75de26a3-6058-4cc4-8edb-7cf633289a35"> |

| before | after |
| - | - |
| <img src="https://github.com/discretize/discretize-ui/assets/8336245/c2b92d56-573b-46cb-8bcf-b099a84114f4"> | <img src="https://github.com/discretize/discretize-ui/assets/8336245/d6a51f83-fdff-4b62-9ddc-74f6a76dd36f"> |
