### PR TITLE
fix: helper icon vertical alignment

### DIFF
--- a/react-discretize-components/src/helpers/HelperIcon/HelperIcon.module.css
+++ b/react-discretize-components/src/helpers/HelperIcon/HelperIcon.module.css
@@ -2,6 +2,6 @@
   width: 1em;
   height: 1em;
   display: inline-block;
-  margin-bottom: -2px !important;
+  vertical-align: text-top;
   color: var(--rdc-color-primary);
 }


### PR DESCRIPTION
Same alignment as `<Icon inline />`, I believe.

Tested in gear optimizer; I don't think the main site actually uses this component?