### PR TITLE
Feat: Deploy both gw2-ui and react-discretize-components storybooks

### DIFF
--- a/.github/workflows/deploy-storybooks.yml
+++ b/.github/workflows/deploy-storybooks.yml
@@ -1,0 +1,54 @@
+name: Deploy Storybooks
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: 'deploy'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      deployments: write
+      pages: write
+      id-token: write
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Build Storybooks
+        run: pnpm -r build-storybook-root
+
+      - name: Setup Github Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './storybook-static'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/gw2-ui/README.md
+++ b/gw2-ui/README.md
@@ -11,6 +11,10 @@ gw2-ui-new is a fork of [gw2-ui](https://github.com/ManuelHaag/gw2-ui) by Manuel
 
 ---
 
+## Storybook
+
+An interactive [storybook.js](https://storybook.js.org/) workshop demonstrating all of the exported components is available at [marcustyphoon.github.io/discretize-ui/gw2-ui](https://marcustyphoon.github.io/discretize-ui/gw2-ui).
+
 ## Installation
 
 Prerequisites:

--- a/gw2-ui/package.json
+++ b/gw2-ui/package.json
@@ -35,7 +35,8 @@
     "build": "node ../build.mjs",
     "api-typecheck": "node ./api_typecheck.mjs",
     "generate-from-api": "node --experimental-fetch ./generate_from_api.mjs",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "build-storybook-root": "pnpm build-storybook --output-dir ../storybook-static/gw2-ui"
   },
   "dependencies": {
     "@discretize/typeface-menomonia": "workspace:^",

--- a/gw2-ui/package.json
+++ b/gw2-ui/package.json
@@ -35,9 +35,7 @@
     "build": "node ../build.mjs",
     "api-typecheck": "node ./api_typecheck.mjs",
     "generate-from-api": "node --experimental-fetch ./generate_from_api.mjs",
-    "deploy-storybook": "gh-pages -d storybook-static",
-    "prepublish": "pnpm build",
-    "postpublish": "pnpm build-storybook && pnpm deploy-storybook && rimraf ./storybook-static "
+    "prepublish": "pnpm build"
   },
   "dependencies": {
     "@discretize/typeface-menomonia": "workspace:^",
@@ -47,7 +45,6 @@
   },
   "devDependencies": {
     "@floating-ui/react-dom": "^1.3.0",
-    "gh-pages": "^6.1.1",
     "ttypescript": "^1.5.15",
     "typescript-is": "^0.19.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
       '@floating-ui/react-dom':
         specifier: ^1.3.0
         version: 1.3.0(react-dom@18.3.1)(react@18.3.1)
-      gh-pages:
-        specifier: ^6.1.1
-        version: 6.1.1
       ttypescript:
         specifier: ^1.5.15
         version: 1.5.15(ts-node@10.9.2)(typescript@4.7.4)
@@ -4395,21 +4392,9 @@ packages:
       is-string: 1.0.7
     dev: true
 
-  /array-union@1.0.2:
-    resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-uniq: 1.0.3
-    dev: true
-
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /array-uniq@1.0.3:
-    resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /array.prototype.findlast@1.2.5:
@@ -4904,11 +4889,6 @@ packages:
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-    dev: true
-
-  /commander@11.1.0:
-    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
-    engines: {node: '>=16'}
     dev: true
 
   /commander@2.20.3:
@@ -5500,10 +5480,6 @@ packages:
     resolution: {integrity: sha512-kSmJl2ZwhNf/bcIuCH/imtNOKlpkLDn2jqT5FJ+/0CXjhnFaOa9cOe9gHKKy71eM49izwuQjZhKk+lWQ1JxB7A==}
     dev: true
 
-  /email-addresses@5.0.0:
-    resolution: {integrity: sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==}
-    dev: true
-
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
@@ -5754,6 +5730,7 @@ packages:
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+    requiresBuild: true
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -6210,20 +6187,6 @@ packages:
       minimatch: 5.1.6
     dev: true
 
-  /filename-reserved-regex@2.0.0:
-    resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /filenamify@4.3.0:
-    resolution: {integrity: sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==}
-    engines: {node: '>=8'}
-    dependencies:
-      filename-reserved-regex: 2.0.0
-      strip-outer: 1.0.1
-      trim-repeated: 1.0.0
-    dev: true
-
   /fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -6494,20 +6457,6 @@ packages:
       get-intrinsic: 1.2.4
     dev: true
 
-  /gh-pages@6.1.1:
-    resolution: {integrity: sha512-upnohfjBwN5hBP9w2dPE7HO5JJTHzSGMV1JrLrHvNuqmjoYHg6TBrCcnEoorjG/e0ejbuvnwyKMdTyM40PEByw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      async: 3.2.5
-      commander: 11.1.0
-      email-addresses: 5.0.0
-      filenamify: 4.3.0
-      find-cache-dir: 3.3.2
-      fs-extra: 11.2.0
-      globby: 6.1.0
-    dev: true
-
   /giget@1.2.3:
     resolution: {integrity: sha512-8EHPljDvs7qKykr6uw8b+lqLiUc/vUg+KVTI0uND4s63TdsZM2Xus3mflvF0DDG9SiM4RlCkFGL+7aAjRmV7KA==}
     hasBin: true
@@ -6610,17 +6559,6 @@ packages:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
-    dev: true
-
-  /globby@6.1.0:
-    resolution: {integrity: sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-union: 1.0.2
-      glob: 7.2.3
-      object-assign: 4.1.1
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
     dev: true
 
   /gopd@1.0.1:
@@ -8271,11 +8209,6 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -8285,18 +8218,6 @@ packages:
   /pify@5.0.0:
     resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /pinkie-promise@2.0.1:
-    resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      pinkie: 2.0.4
-    dev: true
-
-  /pinkie@2.0.4:
-    resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /pirates@4.0.6:
@@ -9765,13 +9686,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strip-outer@1.0.1:
-    resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      escape-string-regexp: 1.0.5
-    dev: true
-
   /style-inject@0.3.0:
     resolution: {integrity: sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==}
     dev: true
@@ -9994,13 +9908,6 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
-
-  /trim-repeated@1.0.0:
-    resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      escape-string-regexp: 1.0.5
     dev: true
 
   /ts-api-utils@1.3.0(typescript@4.7.4):

--- a/react-discretize-components/README.md
+++ b/react-discretize-components/README.md
@@ -1,5 +1,9 @@
 react-discretize-components contains shared react components for all discretize projects. For example usage please refer to the gear-optimizer repository. At the moment this library will only work in gatsby projects.
 
+## Storybook
+
+An interactive [storybook.js](https://storybook.js.org/) workshop demonstrating all of the exported components is available at [marcustyphoon.github.io/discretize-ui/react-discretize-components](https://marcustyphoon.github.io/discretize-ui/react-discretize-components).
+
 ## Installation
 
 ```

--- a/react-discretize-components/package.json
+++ b/react-discretize-components/package.json
@@ -21,7 +21,8 @@
     "build-storybook": "storybook build",
     "build": "node ../build.mjs",
     "//serve": "rollup -c -w --environment BUILD:development",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "build-storybook-root": "pnpm build-storybook --output-dir ../storybook-static/react-discretize-components"
   },
   "dependencies": {
     "@discretize/gw2-ui-new": "workspace:^",


### PR DESCRIPTION
Possible method to deploy both storybooks even though github pages only gives you one site per repository:

 - Build both storybooks into subfolders of the same folder in the repo root
 - Deploy the whole subfolder to github pages in an action

This, notably:

 - Doesn't deploy the storybook in `postpublish` any more (you're deploying two packages now; "deploy when you publish one of them" doesn't really make sense)
 - Does deploy the storybooks either whenever you push to main (making the storybooks reflect the dev branch instead of the current version on npm; don't love that) or only manually on workflow dispatch (ew). Can probably change that to on release in theory; that would probably involve syncing rdc and gw2-ui releases.
 - Requires a change to the repository github pages settings or it'll fail (`gh-pages` deploys from a different branch than `actions/deploy-pages`).

Notable way to do this with fewer caveats: just deploy the storybooks to Cloudflare Pages instead. Could keep doing them separately in `postpublish` then, so long as the developer running `publish` has wrangler keys.