### PR TITLE
chore: Update globals deps

### DIFF
--- a/globals/package.json
+++ b/globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discretize/globals",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "MUI dependencies, global variables, theme related stuff",
   "author": "gw2princeps",
   "license": "MIT",

--- a/globals/package.json
+++ b/globals/package.json
@@ -20,8 +20,8 @@
     "prepublish": "pnpm build"
   },
   "devDependencies": {
-    "@mui/material": "^5.16.5",
-    "@mui/styles": "^5.16.5",
+    "@mui/material": "^6.1.0",
+    "@mui/styles": "^6.1.0",
     "react": "^18.3.1",
     "tss-react": "^4.9.11"
   },

--- a/globals/package.json
+++ b/globals/package.json
@@ -19,15 +19,16 @@
     "build": "node ../build.mjs",
     "prepublish": "pnpm build"
   },
-  "dependencies": {
+  "devDependencies": {
     "@mui/material": "^5.16.5",
     "@mui/styles": "^5.16.5",
+    "react": "^18.3.1",
     "tss-react": "^4.9.11"
   },
-  "devDependencies": {
-    "react": "^18.3.1"
-  },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "@mui/material": "^5.0.0 || ^6.0.0",
+    "@mui/styles": "^5.0.0 || ^6.0.0",
+    "react": "^18.0.0",
+    "tss-react": "^4.0.0"
   }
 }

--- a/globals/src/styles/Layout.jsx
+++ b/globals/src/styles/Layout.jsx
@@ -18,7 +18,7 @@ const Layout = ({ children, ContainerProps, disableContainer = false }) => {
             {children}
           </Box>
         </Container>
-      )) || <Box p={2}>{children}</Box>}
+      )) || <Box sx={{ p: 2 }}>{children}</Box>}
     </>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,20 +134,19 @@ importers:
         version: 5.1.0(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.7.4))(typescript@4.7.4)
 
   globals:
-    dependencies:
-      '@mui/material':
-        specifier: ^5.16.5
-        version: 5.16.5(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/styles':
-        specifier: ^5.16.5
-        version: 5.16.5(@types/react@18.3.7)(react@18.3.1)
-      tss-react:
-        specifier: ^4.9.11
-        version: 4.9.11(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@mui/material@5.16.5(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@mui/material':
+        specifier: ^6.1.0
+        version: 6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/styles':
+        specifier: ^6.1.0
+        version: 6.1.2(@types/react@18.3.7)(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      tss-react:
+        specifier: ^4.9.11
+        version: 4.9.11(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@mui/material@6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
 
   gw2-ui:
     dependencies:
@@ -1120,67 +1119,70 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@mui/core-downloads-tracker@5.16.7':
-    resolution: {integrity: sha512-RtsCt4Geed2/v74sbihWzzRs+HsIQCfclHeORh5Ynu2fS4icIKozcSubwuG7vtzq2uW3fOR1zITSP84TNt2GoQ==}
+  '@mui/core-downloads-tracker@6.1.2':
+    resolution: {integrity: sha512-1oE4U38/TtzLWRYWEm/m70dUbpcvBx0QvDVg6NtpOmSNQC1Mbx0X/rNvYDdZnn8DIsAiVQ+SZ3am6doSswUQ4g==}
 
-  '@mui/material@5.16.5':
-    resolution: {integrity: sha512-eQrjjg4JeczXvh/+8yvJkxWIiKNHVptB/AqpsKfZBWp5mUD5U3VsjODMuUl1K2BSq0omV3CiO/mQmWSSMKSmaA==}
-    engines: {node: '>=12.0.0'}
+  '@mui/material@6.1.2':
+    resolution: {integrity: sha512-5TtHeAVX9D5d2LYfB1GAUn29BcVETVsrQ76Dwb2SpAfQGW3JVy4deJCAd0RrIkI3eEUrsl0E4xuBdreszxdTTg==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
+      '@mui/material-pigment-css': ^6.1.2
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
       '@emotion/styled':
         optional: true
+      '@mui/material-pigment-css':
+        optional: true
       '@types/react':
         optional: true
 
-  '@mui/private-theming@5.16.6':
-    resolution: {integrity: sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==}
-    engines: {node: '>=12.0.0'}
+  '@mui/private-theming@6.1.2':
+    resolution: {integrity: sha512-S8WcjZdNdi++8UhrrY8Lton5h/suRiQexvdTfdcPAlbajlvgM+kx+uJstuVIEyTb3gMkxzIZep87knZ0tqcR0g==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@5.16.6':
-    resolution: {integrity: sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==}
-    engines: {node: '>=12.0.0'}
+  '@mui/styled-engine@6.1.2':
+    resolution: {integrity: sha512-uKOfWkR23X39xj7th2nyTcCHqInTAXtUnqD3T5qRVdJcOPvu1rlgTleTwJC/FJvWZJBU6ieuTWDhbcx5SNViHQ==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
       '@emotion/styled': ^11.3.0
-      react: ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
       '@emotion/styled':
         optional: true
 
-  '@mui/styles@5.16.5':
-    resolution: {integrity: sha512-E6h6Qd1FNsKozeBQCVpfSngxgigkP5+N8IKiD97ItKaEvaCmYg4/akLVj57Y9tj9OloZxqL8IQS80hw5zF19PA==}
-    engines: {node: '>=12.0.0'}
+  '@mui/styles@6.1.2':
+    resolution: {integrity: sha512-fsQkTCyyBnjsmy7CM0LG95PJZAhTsmoC/iNk4ihVYmdubMQEeGXzeAWL8E6QBChCnANmjZwm2h5ENyLnCUUuzg==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/system@5.16.7':
-    resolution: {integrity: sha512-Jncvs/r/d/itkxh7O7opOunTqbbSSzMTHzZkNLM+FjAOg+cYAZHrPDlYe1ZGKUYORwwb2XexlWnpZp0kZ4AHuA==}
-    engines: {node: '>=12.0.0'}
+  '@mui/system@6.1.2':
+    resolution: {integrity: sha512-mzW7F1ZMIYS1aLON48Nrk9c65OrVEVQ+R4lUcTWs1lCSul0VGK23eo4dmY0NX5PS7Oe4xz3P5B9tQZZ7SYgxcg==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
@@ -1189,20 +1191,20 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/types@7.2.16':
-    resolution: {integrity: sha512-qI8TV3M7ShITEEc8Ih15A2vLzZGLhD+/UPNwck/hcls2gwg7dyRjNGXcQYHKLB5Q7PuTRfrTkAoPa2VV1s67Ag==}
+  '@mui/types@7.2.17':
+    resolution: {integrity: sha512-oyumoJgB6jDV8JFzRqjBo2daUuHpzDjoO/e3IrRhhHo/FxJlaVhET6mcNrKHUq2E+R+q3ql0qAtvQ4rfWHhAeQ==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/utils@5.16.6':
-    resolution: {integrity: sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==}
-    engines: {node: '>=12.0.0'}
+  '@mui/utils@6.1.2':
+    resolution: {integrity: sha512-6+B1YZ8cCBWD1fc3RjqpclF9UA0MLUiuXhyCO+XowD/Z2ku5IlxeEhHHlgglyBWFGMu4kib4YU3CDsG5/zVjJQ==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5698,15 +5700,15 @@ snapshots:
       '@types/react': 18.3.7
       react: 18.3.1
 
-  '@mui/core-downloads-tracker@5.16.7': {}
+  '@mui/core-downloads-tracker@6.1.2': {}
 
-  '@mui/material@5.16.5(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/material@6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@mui/core-downloads-tracker': 5.16.7
-      '@mui/system': 5.16.7(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react@18.3.1)
-      '@mui/types': 7.2.16(@types/react@18.3.7)
-      '@mui/utils': 5.16.6(@types/react@18.3.7)(react@18.3.1)
+      '@mui/core-downloads-tracker': 6.1.2
+      '@mui/system': 6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react@18.3.1)
+      '@mui/types': 7.2.17(@types/react@18.3.7)
+      '@mui/utils': 6.1.2(@types/react@18.3.7)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.11
       clsx: 2.1.1
@@ -5720,32 +5722,33 @@ snapshots:
       '@emotion/react': 11.13.3(@types/react@18.3.7)(react@18.3.1)
       '@types/react': 18.3.7
 
-  '@mui/private-theming@5.16.6(@types/react@18.3.7)(react@18.3.1)':
+  '@mui/private-theming@6.1.2(@types/react@18.3.7)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@mui/utils': 5.16.6(@types/react@18.3.7)(react@18.3.1)
+      '@mui/utils': 6.1.2(@types/react@18.3.7)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.7
 
-  '@mui/styled-engine@5.16.6(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(react@18.3.1)':
+  '@mui/styled-engine@6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
       '@emotion/cache': 11.13.1
+      '@emotion/sheet': 1.4.0
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.7)(react@18.3.1)
 
-  '@mui/styles@5.16.5(@types/react@18.3.7)(react@18.3.1)':
+  '@mui/styles@6.1.2(@types/react@18.3.7)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
       '@emotion/hash': 0.9.2
-      '@mui/private-theming': 5.16.6(@types/react@18.3.7)(react@18.3.1)
-      '@mui/types': 7.2.16(@types/react@18.3.7)
-      '@mui/utils': 5.16.6(@types/react@18.3.7)(react@18.3.1)
+      '@mui/private-theming': 6.1.2(@types/react@18.3.7)(react@18.3.1)
+      '@mui/types': 7.2.17(@types/react@18.3.7)
+      '@mui/utils': 6.1.2(@types/react@18.3.7)(react@18.3.1)
       clsx: 2.1.1
       csstype: 3.1.3
       hoist-non-react-statics: 3.3.2
@@ -5762,13 +5765,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.7
 
-  '@mui/system@5.16.7(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react@18.3.1)':
+  '@mui/system@6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@mui/private-theming': 5.16.6(@types/react@18.3.7)(react@18.3.1)
-      '@mui/styled-engine': 5.16.6(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.16(@types/react@18.3.7)
-      '@mui/utils': 5.16.6(@types/react@18.3.7)(react@18.3.1)
+      '@mui/private-theming': 6.1.2(@types/react@18.3.7)(react@18.3.1)
+      '@mui/styled-engine': 6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(react@18.3.1)
+      '@mui/types': 7.2.17(@types/react@18.3.7)
+      '@mui/utils': 6.1.2(@types/react@18.3.7)(react@18.3.1)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -5777,14 +5780,14 @@ snapshots:
       '@emotion/react': 11.13.3(@types/react@18.3.7)(react@18.3.1)
       '@types/react': 18.3.7
 
-  '@mui/types@7.2.16(@types/react@18.3.7)':
+  '@mui/types@7.2.17(@types/react@18.3.7)':
     optionalDependencies:
       '@types/react': 18.3.7
 
-  '@mui/utils@5.16.6(@types/react@18.3.7)(react@18.3.1)':
+  '@mui/utils@6.1.2(@types/react@18.3.7)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@mui/types': 7.2.16(@types/react@18.3.7)
+      '@mui/types': 7.2.17(@types/react@18.3.7)
       '@types/prop-types': 15.7.13
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -9408,7 +9411,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tss-react@4.9.11(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@mui/material@5.16.5(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  tss-react@4.9.11(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@mui/material@6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@emotion/cache': 11.13.1
       '@emotion/react': 11.13.3(@types/react@18.3.7)(react@18.3.1)
@@ -9416,7 +9419,7 @@ snapshots:
       '@emotion/utils': 1.4.0
       react: 18.3.1
     optionalDependencies:
-      '@mui/material': 5.16.5(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/material': 6.1.2(@emotion/react@11.13.3(@types/react@18.3.7)(react@18.3.1))(@types/react@18.3.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   tsutils@3.21.0(typescript@4.7.4):
     dependencies:


### PR DESCRIPTION
Changes the globals package dependencies to peer deps and allows MUI v6 so it doesn't install v5 in v6 projects.