### PR TITLE
feat: Deploy both gw2-ui and RDC storybooks

### DIFF
--- a/deploy-storybook.mjs
+++ b/deploy-storybook.mjs
@@ -1,0 +1,35 @@
+import ghpages from 'gh-pages';
+import { access, constants } from 'node:fs/promises';
+import path from 'node:path';
+
+const workspace = path.basename(process.cwd());
+
+const publish = (dir, options) =>
+  new Promise((resolve) => ghpages.publish(dir, options, resolve));
+
+async function deploy() {
+  try {
+    await access('storybook-static', constants.R_OK);
+  } catch {
+    console.error(
+      `Please build the ${workspace} storybook before deploying it.`,
+    );
+    return;
+  }
+
+  await publish('../github-pages', {
+    message: `Update index`,
+    add: true,
+    nojekyll: true,
+  });
+  console.log('Deployed github-pages folder contents!');
+
+  await publish('storybook-static', {
+    message: `Update ${workspace}`,
+    dest: `${workspace}`,
+    nojekyll: true,
+  });
+  console.log(`Deployed ${workspace} storybook!`);
+}
+
+deploy();

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Redirecting...</title>
+    <link
+      rel="canonical"
+      href="https://discretize.github.io/discretize-ui/gw2-ui/"
+    />
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="refresh"
+      content="0; URL=https://discretize.github.io/discretize-ui/gw2-ui/"
+    />
+  </head>
+</html>

--- a/gw2-ui/package.json
+++ b/gw2-ui/package.json
@@ -35,7 +35,7 @@
     "build": "node ../build.mjs",
     "api-typecheck": "node ./api_typecheck.mjs",
     "generate-from-api": "node --experimental-fetch ./generate_from_api.mjs",
-    "deploy-storybook": "gh-pages -d storybook-static",
+    "deploy-storybook": "node ../deploy-storybook.mjs",
     "prepublish": "pnpm build",
     "postpublish": "pnpm build-storybook && pnpm deploy-storybook && rimraf ./storybook-static "
   },

--- a/react-discretize-components/package.json
+++ b/react-discretize-components/package.json
@@ -21,7 +21,9 @@
     "build-storybook": "storybook build",
     "build": "node ../build.mjs",
     "//serve": "rollup -c -w --environment BUILD:development",
-    "prepublish": "pnpm build"
+    "deploy-storybook": "node ../deploy-storybook.mjs",
+    "prepublish": "pnpm build",
+    "postpublish": "pnpm build-storybook && pnpm deploy-storybook && rimraf ./storybook-static "
   },
   "dependencies": {
     "@discretize/gw2-ui-new": "workspace:^",


### PR DESCRIPTION
Right now, we have the gw2-ui storybook deployed to https://discretize.github.io/discretize-ui for easy public reference, but we don't have the react-discretize components storybook deployed anywhere. This means the only way to access it is be to clone the repo and build it, and that'll build the latest version, not what's actually on NPM. It would be great if https://discretize.github.io/discretize-ui/gw2-ui pointed to the gw2-ui storybook, https://discretize.github.io/discretize-ui/react-discretize-components pointed to the RDC storybook, and https://discretize.github.io/discretize-ui was either a landing page or (for consistency) redirected to the gw2-ui one, right? Well, this does that.

Tested on my fork: 
- https://marcustyphoon.github.io/discretize-ui/gw2-ui
- https://marcustyphoon.github.io/discretize-ui/react-discretize-components
- https://marcustyphoon.github.io/discretize-ui

To implement this, `gh-pages` is used first to upload the contents of a folder containing index.html to the github pages branch root, then to upload the storybook content to a github pages branch subfolder. (This could be done entirely using `gh-pages` CLI mode flags, but a node script is more flexible.)

Note: this preserves the current behavior where storybooks are deployed to github pages only on publish. This means the public storybooks will correspond with the latest package version deployed to NPM, not including any changes that have been pushed to main but not yet published.

If one is merging this without also version bumping and publishing gw2-ui and RDC, one should therefore manually upload versions of the storybooks to the gh-pages branch that are compiled from the published versions, to preserve this.