### PR TITLE
fix(gw2-ui): Types for partial props overrides

### DIFF
--- a/gw2-ui/src/components/CustomComponent/CustomComponent.tsx
+++ b/gw2-ui/src/components/CustomComponent/CustomComponent.tsx
@@ -20,8 +20,8 @@ export interface CustomComponentProps
   text?: string;
   disableLink?: boolean;
   disableTooltip?: boolean;
-  tooltipProps?: TooltipProps;
-  wikiLinkProps?: WikiLinkProps;
+  tooltipProps?: Partial<TooltipProps>;
+  wikiLinkProps?: Partial<WikiLinkProps>;
 }
 
 const CustomComponent = (props: CustomComponentProps): ReactElement => {

--- a/gw2-ui/src/components/DetailsHeader/DetailsHeader.tsx
+++ b/gw2-ui/src/components/DetailsHeader/DetailsHeader.tsx
@@ -11,7 +11,7 @@ export interface DetailsHeaderFlagProps {
 
 export interface DetailsHeaderProps {
   icon?: string;
-  iconProps?: IconProps;
+  iconProps?: Partial<IconProps>;
   titleClassName?: string;
   flags?: DetailsHeaderFlagProps[];
   className?: string;

--- a/gw2-ui/src/components/Effect/Effect.tsx
+++ b/gw2-ui/src/components/Effect/Effect.tsx
@@ -28,10 +28,10 @@ export interface EffectProps {
   disableLink?: boolean;
   disableIcon?: boolean;
   inline?: boolean;
-  tooltipProps?: TooltipProps;
-  wikiLinkProps?: WikiLinkProps;
-  errorProps?: ErrorProps;
-  iconProps?: IconProps;
+  tooltipProps?: Partial<TooltipProps>;
+  wikiLinkProps?: Partial<WikiLinkProps>;
+  errorProps?: Partial<ErrorProps>;
+  iconProps?: Partial<IconProps>;
   className?: string;
   style?: CSSProperties;
 }

--- a/gw2-ui/src/components/Error/Error.tsx
+++ b/gw2-ui/src/components/Error/Error.tsx
@@ -22,7 +22,7 @@ export interface ErrorProps {
   disableText?: boolean;
   disableTooltip?: boolean;
   inline?: boolean;
-  tooltipProps?: TooltipProps;
+  tooltipProps?: Partial<TooltipProps>;
   className?: string;
   style?: CSSProperties;
 }

--- a/gw2-ui/src/components/IconWithText/IconWithText.tsx
+++ b/gw2-ui/src/components/IconWithText/IconWithText.tsx
@@ -11,9 +11,9 @@ export interface IconWithTextProps {
   disableIcon?: boolean;
   disableText?: boolean;
   inline?: boolean;
-  iconProps?: IconProps;
+  iconProps?: Partial<IconProps>;
   textProps?: any;
-  progressProps?: ProgressProps;
+  progressProps?: Partial<ProgressProps>;
   loading?: boolean;
   style?: CSSProperties;
   className?: string;

--- a/gw2-ui/src/components/Item/ItemInternal.tsx
+++ b/gw2-ui/src/components/Item/ItemInternal.tsx
@@ -26,8 +26,8 @@ export interface ItemInternalProps {
   disableLink?: boolean;
   disableTooltip?: boolean;
   inline?: boolean;
-  tooltipProps?: TooltipProps;
-  wikiLinkProps?: WikiLinkProps;
+  tooltipProps?: Partial<TooltipProps>;
+  wikiLinkProps?: Partial<WikiLinkProps>;
   upgrades?: ItemUpgrades;
   style?: CSSProperties;
   className?: string;

--- a/gw2-ui/src/components/Race/Race.tsx
+++ b/gw2-ui/src/components/Race/Race.tsx
@@ -18,8 +18,8 @@ export interface RaceProps {
   disableText?: boolean;
   disableLink?: boolean;
   inline?: boolean;
-  wikiLinkProps?: WikiLinkProps;
-  errorProps?: ErrorProps;
+  wikiLinkProps?: Partial<WikiLinkProps>;
+  errorProps?: Partial<ErrorProps>;
   className?: string;
   style?: CSSProperties;
 }

--- a/gw2-ui/src/components/Skill/SkillInternal.tsx
+++ b/gw2-ui/src/components/Skill/SkillInternal.tsx
@@ -16,8 +16,8 @@ export interface SkillInternalProps
   text?: string;
   disableLink?: boolean;
   disableTooltip?: boolean;
-  tooltipProps?: TooltipProps;
-  wikiLinkProps?: WikiLinkProps;
+  tooltipProps?: Partial<TooltipProps>;
+  wikiLinkProps?: Partial<WikiLinkProps>;
   style?: CSSProperties;
   className?: string;
 }

--- a/gw2-ui/src/components/Trait/TraitInternal.tsx
+++ b/gw2-ui/src/components/Trait/TraitInternal.tsx
@@ -20,8 +20,8 @@ export interface TraitInternalProps {
   disableLink?: boolean;
   disableTooltip?: boolean;
   inline?: boolean;
-  tooltipProps?: TooltipProps;
-  wikiLinkProps?: WikiLinkProps;
+  tooltipProps?: Partial<TooltipProps>;
+  wikiLinkProps?: Partial<WikiLinkProps>;
   inactive?: boolean;
   style?: CSSProperties;
   className?: string;


### PR DESCRIPTION
gw2-ui allows the user to override child component props in certain cases by spreading the override value. These should be typed as partial rather than requiring the entire set of required props.