### PR TITLE
chore: Update API types

### DIFF
--- a/gw2-ui/src/gw2api/types/common/fact.ts
+++ b/gw2-ui/src/gw2api/types/common/fact.ts
@@ -12,7 +12,8 @@ interface GW2ApiFactBase {
 export interface GW2ApiFactAttributeAdjust extends GW2ApiFactBase {
   type: 'AttributeAdjust';
   value?: number;
-  target: GW2ApiAttribute | 'None'; // TODO: why does the API return None sometimes?
+  hit_count?: number;
+  target?: GW2ApiAttribute | 'None'; // TODO: why does the API return None sometimes?
 }
 
 export interface GW2ApiFactBuff extends GW2ApiFactBase {

--- a/gw2-ui/src/gw2api/types/items/details/consumable.ts
+++ b/gw2-ui/src/gw2api/types/items/details/consumable.ts
@@ -31,7 +31,8 @@ type GW2ApiUnlockType =
   | 'SharedSlot'
   | 'GearLoadoutTab'
   | 'BuildLibrarySlot'
-  | 'BuildLoadoutTab';
+  | 'BuildLoadoutTab'
+  | 'JadeBotSkin';
 
 interface GW2ApiConsumableDetails {
   type: GW2ApiConsumableType;

--- a/gw2-ui/src/gw2api/types/items/details/gatheringTool.ts
+++ b/gw2-ui/src/gw2api/types/items/details/gatheringTool.ts
@@ -1,5 +1,5 @@
 interface GW2ApiGatheringToolDetails {
-  type: 'Foraging' | 'Logging' | 'Mining' | 'Foo';
+  type: 'Foraging' | 'Logging' | 'Mining' | 'Foo' | 'Bait' | 'Lure';
 }
 
 export default GW2ApiGatheringToolDetails;

--- a/gw2-ui/src/gw2api/types/items/item.ts
+++ b/gw2-ui/src/gw2api/types/items/item.ts
@@ -161,13 +161,17 @@ export interface GW2ApiItemUpgradeComponent extends GW2ApiItemBase {
   type: 'UpgradeComponent';
   details: WrapInUndefined<GW2ApiUpgradeComponentDetails>;
 }
+export interface GW2ApiItemRelic extends GW2ApiItemBase {
+  type: 'Relic';
+  details?: undefined;
+}
 export interface GW2ApiItemWeapon extends GW2ApiItemBase {
   type: 'Weapon';
   details: WrapInUndefined<GW2ApiWeaponDetails>;
 }
 
 export interface GW2ApiItemJadeBot extends GW2ApiItemBase {
-  type: 'Quux' | 'Qux'; // Don't ask
+  type: 'JadeTechModule' | 'PowerCore';
   details?: undefined;
 }
 
@@ -187,6 +191,7 @@ type GW2ApiItem =
   | GW2ApiItemTrinket
   | GW2ApiItemTrophy
   | GW2ApiItemUpgradeComponent
+  | GW2ApiItemRelic
   | GW2ApiItemWeapon
   | GW2ApiItemJadeBot;
 export default GW2ApiItem;


### PR DESCRIPTION
Uses `pnpm api-typecheck`. Note that this will fail unless you replace `WrapInUndefined` with a no-op, as per the comment, in `gw2-ui/src/gw2api/types/items/item.ts`.

Intentionally not merging this yet, as it's a good test case for an upgrade of the `api-typecheck` script dependencies to support typescript versions >4.7.4.