### PR TITLE
chore: Use modern compatible default type export syntax

### DIFF
--- a/gw2-ui/src/builder/valueOf.ts
+++ b/gw2-ui/src/builder/valueOf.ts
@@ -1,3 +1,3 @@
 type ValueOf<T> = T[keyof T];
 
-export default ValueOf;
+export type { ValueOf as default };

--- a/gw2-ui/src/gw2api/types/common/armorSlotType.ts
+++ b/gw2-ui/src/gw2api/types/common/armorSlotType.ts
@@ -7,4 +7,4 @@ type GW2ApiArmorSlotType =
   | 'Leggings'
   | 'Shoulders';
 
-export default GW2ApiArmorSlotType;
+export type { GW2ApiArmorSlotType as default };

--- a/gw2-ui/src/gw2api/types/common/armorType.ts
+++ b/gw2-ui/src/gw2api/types/common/armorType.ts
@@ -1,3 +1,3 @@
 type GW2ApiArmorType = 'HeavyArmor' | 'MediumArmor' | 'LightArmor';
 
-export default GW2ApiArmorType;
+export type { GW2ApiArmorType as default };

--- a/gw2-ui/src/gw2api/types/common/attribute.ts
+++ b/gw2-ui/src/gw2api/types/common/attribute.ts
@@ -10,4 +10,4 @@ type GW2ApiAttribute =
   | 'Toughness'
   | 'Vitality';
 
-export default GW2ApiAttribute;
+export type { GW2ApiAttribute as default };

--- a/gw2-ui/src/gw2api/types/common/comboFieldType.ts
+++ b/gw2-ui/src/gw2api/types/common/comboFieldType.ts
@@ -10,4 +10,4 @@ type GW2ApiComboFieldType =
   | 'Ethereal'
   | 'Water';
 
-export default GW2ApiComboFieldType;
+export type { GW2ApiComboFieldType as default };

--- a/gw2-ui/src/gw2api/types/common/containerType.ts
+++ b/gw2-ui/src/gw2api/types/common/containerType.ts
@@ -1,3 +1,3 @@
 type GW2ApiContainerType = 'Default' | 'GiftBox' | 'Immediate' | 'OpenUI';
 
-export default GW2ApiContainerType;
+export type { GW2ApiContainerType as default };

--- a/gw2-ui/src/gw2api/types/common/damageType.ts
+++ b/gw2-ui/src/gw2api/types/common/damageType.ts
@@ -1,3 +1,3 @@
 type GW2ApiDamageType = 'Fire' | 'Ice' | 'Lightning' | 'Physical' | 'Choking';
 
-export default GW2ApiDamageType;
+export type { GW2ApiDamageType as default };

--- a/gw2-ui/src/gw2api/types/common/fact.ts
+++ b/gw2-ui/src/gw2api/types/common/fact.ts
@@ -143,6 +143,6 @@ export type GW2ApiFact =
   | GW2ApiFactTime
   | GW2ApiFactUnblockable;
 
-export default GW2ApiFact;
+export type { GW2ApiFact as default };
 
 export type GW2ApiFactType = GW2ApiFact['type'];

--- a/gw2-ui/src/gw2api/types/common/gameType.ts
+++ b/gw2-ui/src/gw2api/types/common/gameType.ts
@@ -1,4 +1,4 @@
 type GW2ApiGameType =
   'Activity' | 'Dungeon' | 'Pve' | 'Pvp' | 'PvpLobby' | 'Wvw';
 
-export default GW2ApiGameType;
+export type { GW2ApiGameType as default };

--- a/gw2-ui/src/gw2api/types/common/gizmoType.ts
+++ b/gw2-ui/src/gw2api/types/common/gizmoType.ts
@@ -1,4 +1,4 @@
 type GW2ApiGizmoType =
   'Default' | 'ContainerKey' | 'RentableContractNpc' | 'UnlimitedConsumable';
 
-export default GW2ApiGizmoType;
+export type { GW2ApiGizmoType as default };

--- a/gw2-ui/src/gw2api/types/common/infusionSlotFlag.ts
+++ b/gw2-ui/src/gw2api/types/common/infusionSlotFlag.ts
@@ -1,3 +1,3 @@
 type GW2ApiInfusionSlotFlag = 'Enrichment' | 'Infusion';
 
-export default GW2ApiInfusionSlotFlag;
+export type { GW2ApiInfusionSlotFlag as default };

--- a/gw2-ui/src/gw2api/types/common/infusionUpgradeFlag.ts
+++ b/gw2-ui/src/gw2api/types/common/infusionUpgradeFlag.ts
@@ -1,4 +1,4 @@
 type GW2ApiInfusionUpgradeFlag =
   'Enrichment' | 'Infusion' | 'Defense' | 'Offense' | 'Utility' | 'Agony';
 
-export default GW2ApiInfusionUpgradeFlag;
+export type { GW2ApiInfusionUpgradeFlag as default };

--- a/gw2-ui/src/gw2api/types/common/profession.ts
+++ b/gw2-ui/src/gw2api/types/common/profession.ts
@@ -2,4 +2,4 @@ import { type ProfessionTypes } from '../../../data/professions';
 
 type GW2ApiProfession = ProfessionTypes;
 
-export default GW2ApiProfession;
+export type { GW2ApiProfession as default };

--- a/gw2-ui/src/gw2api/types/common/salvageKitType.ts
+++ b/gw2-ui/src/gw2api/types/common/salvageKitType.ts
@@ -1,3 +1,3 @@
 type GW2ApiSalvageKitType = 'Salvage';
 
-export default GW2ApiSalvageKitType;
+export type { GW2ApiSalvageKitType as default };

--- a/gw2-ui/src/gw2api/types/common/traited_fact.ts
+++ b/gw2-ui/src/gw2api/types/common/traited_fact.ts
@@ -7,4 +7,4 @@ type GW2ApiTraitedFactAdditional = {
 
 type GW2ApiTraitedFact = GW2ApiFact & GW2ApiTraitedFactAdditional;
 
-export default GW2ApiTraitedFact;
+export type { GW2ApiTraitedFact as default };

--- a/gw2-ui/src/gw2api/types/common/trinketType.ts
+++ b/gw2-ui/src/gw2api/types/common/trinketType.ts
@@ -1,3 +1,3 @@
 type GW2ApiTrinketType = 'Accessory' | 'Amulet' | 'Ring';
 
-export default GW2ApiTrinketType;
+export type { GW2ApiTrinketType as default };

--- a/gw2-ui/src/gw2api/types/common/upgradeComponentType.ts
+++ b/gw2-ui/src/gw2api/types/common/upgradeComponentType.ts
@@ -1,3 +1,3 @@
 type GW2ApiUpgradeComponentType = 'Default' | 'Gem' | 'Rune' | 'Sigil';
 
-export default GW2ApiUpgradeComponentType;
+export type { GW2ApiUpgradeComponentType as default };

--- a/gw2-ui/src/gw2api/types/common/weaponType.ts
+++ b/gw2-ui/src/gw2api/types/common/weaponType.ts
@@ -24,7 +24,7 @@ type GW2ApiWeaponType =
   | GW2ApiAquaticWeaponType
   | GW2ApiOtherWeaponType;
 
-export default GW2ApiWeaponType;
+export type { GW2ApiWeaponType as default };
 
 // Hooray for inconsistencies
 export type GW2ApiWeaponTypeForItemDetails =

--- a/gw2-ui/src/gw2api/types/common/weightClass.ts
+++ b/gw2-ui/src/gw2api/types/common/weightClass.ts
@@ -1,3 +1,3 @@
 type GW2ApiWeightClass = 'Heavy' | 'Medium' | 'Light' | 'Clothing';
 
-export default GW2ApiWeightClass;
+export type { GW2ApiWeightClass as default };

--- a/gw2-ui/src/gw2api/types/items/details/armor.ts
+++ b/gw2-ui/src/gw2api/types/items/details/armor.ts
@@ -15,4 +15,4 @@ interface GW2ApiArmorDetails {
   stat_choices?: number[];
 }
 
-export default GW2ApiArmorDetails;
+export type { GW2ApiArmorDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/backItem.ts
+++ b/gw2-ui/src/gw2api/types/items/details/backItem.ts
@@ -10,4 +10,4 @@ interface GW2ApiBackItemDetails {
   stat_choices?: number[];
 }
 
-export default GW2ApiBackItemDetails;
+export type { GW2ApiBackItemDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/bag.ts
+++ b/gw2-ui/src/gw2api/types/items/details/bag.ts
@@ -3,4 +3,4 @@ interface GW2ApiBagDetails {
   no_sell_or_sort: boolean;
 }
 
-export default GW2ApiBagDetails;
+export type { GW2ApiBagDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/common/infixUpgrade.ts
+++ b/gw2-ui/src/gw2api/types/items/details/common/infixUpgrade.ts
@@ -16,4 +16,4 @@ interface GW2ApiInfixUpgrade {
   buff?: GW2ApiBuff;
 }
 
-export default GW2ApiInfixUpgrade;
+export type { GW2ApiInfixUpgrade as default };

--- a/gw2-ui/src/gw2api/types/items/details/common/infusionSlot.ts
+++ b/gw2-ui/src/gw2api/types/items/details/common/infusionSlot.ts
@@ -5,4 +5,4 @@ export interface GW2ApiInflusionSlot {
   item_id?: number;
 }
 
-export default GW2ApiInflusionSlot;
+export type { GW2ApiInflusionSlot as default };

--- a/gw2-ui/src/gw2api/types/items/details/consumable.ts
+++ b/gw2-ui/src/gw2api/types/items/details/consumable.ts
@@ -49,4 +49,4 @@ interface GW2ApiConsumableDetails {
   skins?: number[];
 }
 
-export default GW2ApiConsumableDetails;
+export type { GW2ApiConsumableDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/container.ts
+++ b/gw2-ui/src/gw2api/types/items/details/container.ts
@@ -4,4 +4,4 @@ interface GW2ApiContainerDetails {
   type: GW2ApiContainerType;
 }
 
-export default GW2ApiContainerDetails;
+export type { GW2ApiContainerDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/details.ts
+++ b/gw2-ui/src/gw2api/types/items/details/details.ts
@@ -38,4 +38,4 @@ type GW2ApiItemDetails =
   | WrapInUndefined<GW2ApiWeaponTypeDetails>
   | WrapInUndefined<GW2ApiUpgradeComponentDetails>;
 
-export default GW2ApiItemDetails;
+export type { GW2ApiItemDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/gatheringTool.ts
+++ b/gw2-ui/src/gw2api/types/items/details/gatheringTool.ts
@@ -2,4 +2,4 @@ interface GW2ApiGatheringToolDetails {
   type: 'Foraging' | 'Logging' | 'Mining' | 'Foo' | 'Bait' | 'Lure';
 }
 
-export default GW2ApiGatheringToolDetails;
+export type { GW2ApiGatheringToolDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/gizmo.ts
+++ b/gw2-ui/src/gw2api/types/items/details/gizmo.ts
@@ -6,4 +6,4 @@ interface GW2ApiGizmoDetails {
   vendor_ids?: number[];
 }
 
-export default GW2ApiGizmoDetails;
+export type { GW2ApiGizmoDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/miniature.ts
+++ b/gw2-ui/src/gw2api/types/items/details/miniature.ts
@@ -2,4 +2,4 @@ interface GW2ApiMiniatureDetails {
   minipet_id: number;
 }
 
-export default GW2ApiMiniatureDetails;
+export type { GW2ApiMiniatureDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/salvageKit.ts
+++ b/gw2-ui/src/gw2api/types/items/details/salvageKit.ts
@@ -5,4 +5,4 @@ interface GW2ApiSalvageKitDetails {
   charges: number;
 }
 
-export default GW2ApiSalvageKitDetails;
+export type { GW2ApiSalvageKitDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/trinket.ts
+++ b/gw2-ui/src/gw2api/types/items/details/trinket.ts
@@ -12,4 +12,4 @@ interface GW2ApiTrinketDetails {
   stat_choices?: number[];
 }
 
-export default GW2ApiTrinketDetails;
+export type { GW2ApiTrinketDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/upgradeComponent.ts
+++ b/gw2-ui/src/gw2api/types/items/details/upgradeComponent.ts
@@ -22,4 +22,4 @@ interface GW2ApiUpgradeComponentDetails {
   attribute_adjustment: number;
 }
 
-export default GW2ApiUpgradeComponentDetails;
+export type { GW2ApiUpgradeComponentDetails as default };

--- a/gw2-ui/src/gw2api/types/items/details/weapon.ts
+++ b/gw2-ui/src/gw2api/types/items/details/weapon.ts
@@ -17,4 +17,4 @@ interface GW2ApiWeaponDetails {
   stat_choices?: number[];
 }
 
-export default GW2ApiWeaponDetails;
+export type { GW2ApiWeaponDetails as default };

--- a/gw2-ui/src/gw2api/types/items/item.ts
+++ b/gw2-ui/src/gw2api/types/items/item.ts
@@ -192,4 +192,4 @@ type GW2ApiItem =
   | GW2ApiItemRelic
   | GW2ApiItemWeapon
   | GW2ApiItemJadeBot;
-export default GW2ApiItem;
+export type { GW2ApiItem as default };

--- a/gw2-ui/src/gw2api/types/specialization/specialization.ts
+++ b/gw2-ui/src/gw2api/types/specialization/specialization.ts
@@ -12,4 +12,4 @@ interface GW2ApiSpecialization {
   weapon_trait?: number;
 }
 
-export default GW2ApiSpecialization;
+export type { GW2ApiSpecialization as default };

--- a/gw2-ui/src/gw2api/types/traits/trait.ts
+++ b/gw2-ui/src/gw2api/types/traits/trait.ts
@@ -24,4 +24,4 @@ interface GW2ApiTrait extends GW2ApiTraitBase {
   skills?: GW2ApiTraitSkill[];
 }
 
-export default GW2ApiTrait;
+export type { GW2ApiTrait as default };


### PR DESCRIPTION
In order to use the verbatimModuleSyntax typescript flag, one must label type-only exports as `export type`, and I guess `export default type` isn't valid syntax, so we get this mess.

I would personally just remove all default exports, honestly, as they're just annoying, but I don't want to make a big, messy diff.